### PR TITLE
Add support for U2F devices for Snap Packaging

### DIFF
--- a/package.json
+++ b/package.json
@@ -211,7 +211,8 @@
       "confinement": "strict",
       "plugs": [
         "default",
-        "password-manager-service"
+        "password-manager-service",
+        "u2f-devices"
       ],
       "stagePackages": [
         "default"


### PR DESCRIPTION
Hello,

Bitwarden Desktop via snap packaging doesn't support U2F (e.g. Yubikey).

This should allow the built snap package to interact with U2F devices.